### PR TITLE
Refactor-project-for-consistency

### DIFF
--- a/Catan/Catan.Domain/CatanBoard.cs
+++ b/Catan/Catan.Domain/CatanBoard.cs
@@ -1,206 +1,187 @@
 ﻿using static Catan.Common.Enumerations;
 
-namespace Catan.Domain
+namespace Catan.Domain;
+
+public sealed class CatanBoard
 {
-    public sealed class CatanBoard
+    private readonly CatanTile[,] tiles;
+    private readonly List<CatanPort> ports;
+    private readonly CatanBuilding[,] houses;
+    private readonly List<CatanRoad> roads;
+
+    private readonly Random random = new();
+
+    public CatanBoard()
     {
-        public Coordinates RobberPosition { get; set; }
+        tiles = new CatanTile[BoardLength, BoardLength];
+        ports = new List<CatanPort>();
+        houses = new CatanBuilding[11, 6];
+        roads = new List<CatanRoad>();
+        RobberPosition = new Coordinates(0, 0);
 
-        public int BoardLength { get; set; } = 5;
+        InitialiseTilesAndSetRobber();
+        InitialiseHouses();
+        InitialiseRoads();
+        InitialisePorts();
+    }
 
-        private readonly CatanTile[,] tiles;
-        private readonly List<CatanPort> ports;
-        private CatanBuilding[,] houses;
-        private List<CatanRoad> roads;
+    public Coordinates RobberPosition { get; private set; }
 
-        private readonly Random random = new();
+    public int BoardLength { get; private set; } = 5;
 
-        public CatanBoard()
+    public CatanTile[,] GetTiles() => tiles;
+
+    public CatanTile GetTile(int x, int y) => tiles[x, y];
+
+    public CatanBuilding[,] GetHouses() => houses;
+
+    public CatanBuilding GetHouse(int x, int y) => houses[x, y];
+
+    public List<CatanRoad> GetRoads() => roads;
+
+    public List<CatanPort> GetPorts() => ports;
+
+    private void InitialiseTilesAndSetRobber()
+    {
+        var remainingResourceTileTypes = DomainConstants.GetTileResourceTypeTotals();
+        var remainingActivationNumbers = DomainConstants.GetTileActivationNumberTotals();
+
+        for (int i = 0; i < BoardLength; i++)
         {
-            tiles = new CatanTile[BoardLength, BoardLength];
-            ports = new List<CatanPort>();
-            houses = new CatanBuilding[11, 6];
-            roads = new List<CatanRoad>();
-            RobberPosition = new Coordinates(0, 0);
-
-            InitialiseTilesAndSetRobber();
-            InitialiseHouses();
-            InitialiseRoads();
-            InitialisePorts();
-        }
-
-        public CatanTile[,] GetTiles()
-        { 
-            return tiles;
-        }
-
-        public CatanTile GetTile(int x, int y)
-        {
-            return tiles[x, y];
-        }
-
-        public CatanBuilding[,] GetHouses()
-        {
-            return houses;
-        }
-
-        public CatanBuilding GetHouse(int x, int y)
-        {
-            return houses[x, y];
-        }
-
-        public List<CatanRoad> GetRoads()
-        {
-            return roads;
-        }
-
-        public List<CatanPort> GetPorts()
-        {
-            return ports;
-        }
-
-        private void InitialiseTilesAndSetRobber()
-        {
-            var remainingResourceTileTypes = DomainConstants.GetTileResourceTypeTotals();
-            var remainingActivationNumbers = DomainConstants.GetTileActivationNumberTotals();
-
-            for (int i = 0; i < BoardLength; i++)
+            for (int j = 0; j < BoardLength; j++)
             {
-                for (int j = 0; j < BoardLength; j++)
+                if (i + j >= 2 && i + j <= BoardLength + 1)
                 {
-                    if (i + j >= 2 && i + j <= BoardLength + 1)
-                    {
-                        tiles[i, j] = CreateNewCatanTile(remainingResourceTileTypes, remainingActivationNumbers);
+                    tiles[i, j] = CreateNewCatanTile(remainingResourceTileTypes, remainingActivationNumbers);
 
-                        if (tiles[i, j].Type == CatanResourceType.Desert)
-                        {
-                            RobberPosition = new Coordinates(i, j);
-                        }
+                    if (tiles[i, j].Type == CatanResourceType.Desert)
+                    {
+                        RobberPosition = new Coordinates(i, j);
                     }
                 }
             }
         }
+    }
 
-        private void InitialiseHouses()
+    private void InitialiseHouses()
+    {
+        for (int i = 0; i < 11; i++)
         {
-            for (int i = 0; i < 11; i++)
+            for (int j = 0; j < 6; j++)
             {
-                for (int j = 0; j < 6; j++)
+                if (i + j >= 2 && i + j <= 13 && j - i <= 3 && j - i >= -8)
                 {
-                    if (i + j >= 2 && i + j <= 13 && j - i <= 3 && j - i >= -8)
+                    houses[i, j] = new CatanBuilding(CatanPlayerColour.None, CatanBuildingType.None);
+                }
+            }
+        }
+    }
+
+    private void InitialiseRoads()
+    {
+        List<Coordinates> roadVectors = new()
+        {
+            new Coordinates(0, -1),
+            new Coordinates(-1, 0)
+        };
+
+        for (int i = 0; i < 11; i++)
+        {
+            for (int j = 0; j < 6; j++)
+            {
+                var house = houses[i, j];
+
+                if (house is null) continue;
+
+                var roadCorner1 = new Coordinates(i, j);
+
+                foreach (var vector in roadVectors)
+                {
+                    var roadCorner2 = Coordinates.Add(vector, roadCorner1);
+
+                    if (roadCorner2.X < 0 || roadCorner2.Y < 0) continue;
+
+                    var road = new CatanRoad(CatanPlayerColour.None, roadCorner1, roadCorner2);
+
+                    if (houses[roadCorner2.X, roadCorner2.Y] is null) continue;
+
+                    if (Math.Min(roadCorner1.Y, roadCorner2.Y) % 2 == roadCorner1.X % 2 || vector.Y == 0)
                     {
-                        houses[i, j] = new CatanBuilding(CatanPlayerColour.None, CatanBuildingType.None);
+                        roads.Add(road);
                     }
                 }
             }
         }
+    }
 
-        private void InitialiseRoads()
+    private void InitialisePorts()
+    {
+        var remainingPortTypes = DomainConstants.GetPortTypeTotals();
+        var allPortLocations = DomainConstants.GetStartingPortCoordinates();
+
+        for (var i = 0; i < allPortLocations.Count; i+=2)
         {
-            List<Coordinates> roadVectors = new()
-            {
-                new Coordinates(0, -1),
-                new Coordinates(-1, 0)
-            };
-
-            for (int i = 0; i < 11; i++)
-            {
-                for (int j = 0; j < 6; j++)
-                {
-                    var house = houses[i, j];
-
-                    if (house is null) continue;
-
-                    var roadCorner1 = new Coordinates(i, j);
-
-                    foreach (var vector in roadVectors)
-                    {
-                        var roadCorner2 = Coordinates.Add(vector, roadCorner1);
-
-                        if (roadCorner2.X < 0 || roadCorner2.Y < 0) continue;
-
-                        var road = new CatanRoad(CatanPlayerColour.None, roadCorner1, roadCorner2);
-
-                        if (houses[roadCorner2.X, roadCorner2.Y] is null) continue;
-
-                        if (Math.Min(roadCorner1.Y, roadCorner2.Y) % 2 == roadCorner1.X % 2 || vector.Y == 0)
-                        {
-                            roads.Add(road);
-                        }
-                    }
-                }
-            }
-        }
-
-        private void InitialisePorts()
-        {
-            var remainingPortTypes = DomainConstants.GetPortTypeTotals();
-            var allPortLocations = DomainConstants.GetStartingPortCoordinates();
-
-            for (var i = 0; i < allPortLocations.Count; i+=2)
-            {
-                CatanPortType catanPortType;
-                int lowestPortTypeNum = (int)remainingPortTypes.First().Key;
-                int highestPortTypeNum = (int)remainingPortTypes.Last().Key;
-
-                do
-                {
-                    catanPortType = (CatanPortType)random.Next(lowestPortTypeNum, highestPortTypeNum + 1);
-                }
-                while (remainingPortTypes[catanPortType] <= 0);
-
-                remainingPortTypes[catanPortType]--;
-
-                var newPort1 = new CatanPort(catanPortType, allPortLocations[i]);
-                var newPort2 = new CatanPort(catanPortType, allPortLocations[i+1]);
-
-                ports.Add(newPort1);
-                ports.Add(newPort2);
-            }
-        }
-
-        private CatanTile CreateNewCatanTile(Dictionary<CatanResourceType, int> remainingResourceTileTypes, Dictionary<int, int> remainingActivationNumbers)
-        {
-            if (remainingResourceTileTypes is null || remainingResourceTileTypes.Count == 0)
-            {
-                throw new ArgumentException($"{nameof(remainingResourceTileTypes)} must not be null or empty.");
-            }
-
-            if (remainingActivationNumbers is null || remainingActivationNumbers.Count == 0)
-            {
-                throw new ArgumentException($"{nameof(remainingActivationNumbers)} must not be null or empty.");
-            }
-
-            CatanResourceType catanTileType;
-            int lowestTileTypeNum = (int)remainingResourceTileTypes.First().Key;
-            int highestTileTypeNum = (int)remainingResourceTileTypes.Last().Key;
+            CatanPortType catanPortType;
+            int lowestPortTypeNum = (int)remainingPortTypes.First().Key;
+            int highestPortTypeNum = (int)remainingPortTypes.Last().Key;
 
             do
             {
-                catanTileType = (CatanResourceType)random.Next(lowestTileTypeNum, highestTileTypeNum + 1);
+                catanPortType = (CatanPortType)random.Next(lowestPortTypeNum, highestPortTypeNum + 1);
             }
-            while (remainingResourceTileTypes[catanTileType] <= 0);
+            while (remainingPortTypes[catanPortType] <= 0);
 
-            remainingResourceTileTypes[catanTileType]--;
+            remainingPortTypes[catanPortType]--;
 
-            if (catanTileType == CatanResourceType.Desert)
-            {
-                return new CatanTile(catanTileType, 0);
-            }
+            var newPort1 = new CatanPort(catanPortType, allPortLocations[i]);
+            var newPort2 = new CatanPort(catanPortType, allPortLocations[i+1]);
 
-            int activationNumber;
-            int lowestActivationNum = remainingActivationNumbers.First().Key;
-            int highestActivationNum = remainingActivationNumbers.Last().Key;
-
-            do
-            {
-                activationNumber = random.Next(lowestActivationNum, highestActivationNum + 1);
-            }
-            while (remainingActivationNumbers[activationNumber] <= 0);
-
-            remainingActivationNumbers[activationNumber]--;
-
-            return new CatanTile(catanTileType, activationNumber);
+            ports.Add(newPort1);
+            ports.Add(newPort2);
         }
+    }
+
+    private CatanTile CreateNewCatanTile(Dictionary<CatanResourceType, int> remainingResourceTileTypes, Dictionary<int, int> remainingActivationNumbers)
+    {
+        if (remainingResourceTileTypes is null || remainingResourceTileTypes.Count == 0)
+        {
+            throw new ArgumentException($"{nameof(remainingResourceTileTypes)} must not be null or empty.");
+        }
+
+        if (remainingActivationNumbers is null || remainingActivationNumbers.Count == 0)
+        {
+            throw new ArgumentException($"{nameof(remainingActivationNumbers)} must not be null or empty.");
+        }
+
+        CatanResourceType catanTileType;
+        int lowestTileTypeNum = (int)remainingResourceTileTypes.First().Key;
+        int highestTileTypeNum = (int)remainingResourceTileTypes.Last().Key;
+
+        do
+        {
+            catanTileType = (CatanResourceType)random.Next(lowestTileTypeNum, highestTileTypeNum + 1);
+        }
+        while (remainingResourceTileTypes[catanTileType] <= 0);
+
+        remainingResourceTileTypes[catanTileType]--;
+
+        if (catanTileType == CatanResourceType.Desert)
+        {
+            return new CatanTile(catanTileType, 0);
+        }
+
+        int activationNumber;
+        int lowestActivationNum = remainingActivationNumbers.First().Key;
+        int highestActivationNum = remainingActivationNumbers.Last().Key;
+
+        do
+        {
+            activationNumber = random.Next(lowestActivationNum, highestActivationNum + 1);
+        }
+        while (remainingActivationNumbers[activationNumber] <= 0);
+
+        remainingActivationNumbers[activationNumber]--;
+
+        return new CatanTile(catanTileType, activationNumber);
     }
 }

--- a/Catan/Catan.Domain/CatanBuilding.cs
+++ b/Catan/Catan.Domain/CatanBuilding.cs
@@ -1,22 +1,22 @@
 ﻿using static Catan.Common.Enumerations;
 
-namespace Catan.Domain
+namespace Catan.Domain;
+
+public class CatanBuilding
 {
-    public class CatanBuilding
+    public CatanBuilding()
     {
-        public CatanPlayerColour Colour { get; set; }
-        public CatanBuildingType Type { get; set; }
-
-        public CatanBuilding()
-        {
-            this.Colour = CatanPlayerColour.None;
-            this.Type = CatanBuildingType.None;
-        }
-
-        public CatanBuilding(CatanPlayerColour colour, CatanBuildingType type)
-        {
-            this.Colour = colour;
-            this.Type = type;
-        }
+        Colour = CatanPlayerColour.None;
+        Type = CatanBuildingType.None;
     }
+
+    public CatanBuilding(CatanPlayerColour colour, CatanBuildingType type)
+    {
+        Colour = colour;
+        Type = type;
+    }
+
+    public CatanPlayerColour Colour { get; private set; }
+    
+    public CatanBuildingType Type { get; private set; }
 }

--- a/Catan/Catan.Domain/CatanGame.cs
+++ b/Catan/Catan.Domain/CatanGame.cs
@@ -1,42 +1,41 @@
 ﻿using static Catan.Common.Enumerations;
 
-namespace Catan.Domain
+namespace Catan.Domain;
+
+public class CatanGame
 {
-    public class CatanGame
+    private CatanBoard board;
+    private List<CatanPlayer> players;
+    private List<int> rolledDice = new();
+    private int diceTotal;
+
+    public CatanGame(int numberOfPlayers)
     {
-        private CatanBoard board;
-        private List<CatanPlayer> players;
-        private List<int> rolledDice = new();
-        private int diceTotal;
+        board = new CatanBoard();
+        players = new List<CatanPlayer>();
 
-        public CatanGame(int numberOfPlayers)
+        RollDice();
+        InitialisePlayers(numberOfPlayers);
+    }
+
+    private void InitialisePlayers(int numberOfPlayers)
+    {
+        List<CatanPlayer> newPlayers = new();
+
+        for (var i = 0; i < numberOfPlayers; i++)
         {
-            board = new CatanBoard();
-            players = new List<CatanPlayer>();
+            CatanPlayerColour playerColour = (CatanPlayerColour)(i + 1);
+            var newPlayer = new CatanPlayer(playerColour);
 
-            RollDice();
-            players = InitialisePlayers(numberOfPlayers);
+            newPlayers.Add(newPlayer);
         }
 
-        private List<CatanPlayer> InitialisePlayers(int numberOfPlayers)
-        {
-            List<CatanPlayer> newPlayers = new();
+        players = newPlayers;
+    }
 
-            for (var i = 0; i < numberOfPlayers; i++)
-            {
-                CatanPlayerColour playerColour = (CatanPlayerColour)(i + 1);
-                var newPlayer = new CatanPlayer(playerColour);
-
-                newPlayers.Add(newPlayer);
-            }
-
-            return newPlayers;
-        }
-
-        private void RollDice()
-        {
-            rolledDice = DiceRoller.RollDice(2, 6);
-            diceTotal = rolledDice.Sum();
-        }
+    private void RollDice()
+    {
+        rolledDice = DiceRoller.RollDice(2, 6);
+        diceTotal = rolledDice.Sum();
     }
 }

--- a/Catan/Catan.Domain/CatanPlayer.cs
+++ b/Catan/Catan.Domain/CatanPlayer.cs
@@ -1,73 +1,72 @@
 ﻿using static Catan.Common.Enumerations;
 
-namespace Catan.Domain
+namespace Catan.Domain;
+
+public class CatanPlayer
 {
-    public class CatanPlayer
+    private readonly Dictionary<CatanResourceType, int> resourceCards;
+    private readonly Dictionary<CatanDevelopmentCardType, int> playableDevelopmentCards;
+    private readonly Dictionary<CatanDevelopmentCardType, int> developmentCardsOnHold;
+
+    public CatanPlayer(CatanPlayerColour colour)
     {
-        public readonly CatanPlayerColour Colour;
+        Colour = colour;
 
-        private readonly Dictionary<CatanResourceType, int> resourceCards;
-        private readonly Dictionary<CatanDevelopmentCardType, int> playableDevelopmentCards;
-        private readonly Dictionary<CatanDevelopmentCardType, int> developmentCardsOnHold;
+        resourceCards = InitialiseResourceCards();
+        playableDevelopmentCards = InitialiseDevelopmentCards();
+        developmentCardsOnHold = InitialiseDevelopmentCards();
+    }
 
-        public CatanPlayer(CatanPlayerColour colour)
+    public CatanPlayerColour Colour { get; private set; }
+
+    public Dictionary<CatanResourceType, int> GetResourceCards()
+    {
+        return resourceCards;
+    }
+
+    public Dictionary<CatanDevelopmentCardType, int> GetPlayableDevelopmentCards()
+    {
+        return playableDevelopmentCards;
+    }
+
+    public Dictionary<CatanDevelopmentCardType, int> GetDevelopmentCardsOnHold()
+    {
+        return developmentCardsOnHold;
+    }
+
+    public void AddDevelopmentCard(CatanDevelopmentCardType type)
+    {
+        if (type == CatanDevelopmentCardType.VictoryPoint)
         {
-            this.Colour = colour;
-
-            resourceCards = InitialiseResourceCards();
-            playableDevelopmentCards = InitialiseDevelopmentCards();
-            developmentCardsOnHold = InitialiseDevelopmentCards();
+            playableDevelopmentCards[CatanDevelopmentCardType.VictoryPoint]++;
         }
-
-        public Dictionary<CatanResourceType, int> GetResourceCards()
+        else
         {
-            return resourceCards;
+            developmentCardsOnHold[type]++;
         }
+    }
 
-        public Dictionary<CatanDevelopmentCardType, int> GetPlayableDevelopmentCards()
+    private Dictionary<CatanResourceType, int> InitialiseResourceCards()
+    {
+        return new Dictionary<CatanResourceType, int>()
         {
-            return playableDevelopmentCards;
-        }
+            { CatanResourceType.Wood, 0 },
+            { CatanResourceType.Brick, 0 },
+            { CatanResourceType.Sheep, 0 },
+            { CatanResourceType.Wheat, 0 },
+            { CatanResourceType.Ore, 0 }
+        };
+    }
 
-        public Dictionary<CatanDevelopmentCardType, int> GetDevelopmentCardsOnHold()
+    private Dictionary<CatanDevelopmentCardType, int> InitialiseDevelopmentCards()
+    {
+        return new Dictionary<CatanDevelopmentCardType, int>()
         {
-            return developmentCardsOnHold;
-        }
-
-        public void AddDevelopmentCard(CatanDevelopmentCardType type)
-        {
-            if (type == CatanDevelopmentCardType.VictoryPoint)
-            {
-                playableDevelopmentCards[CatanDevelopmentCardType.VictoryPoint]++;
-            }
-            else
-            {
-                developmentCardsOnHold[type]++;
-            }
-        }
-
-        private Dictionary<CatanResourceType, int> InitialiseResourceCards()
-        {
-            return new Dictionary<CatanResourceType, int>()
-            {
-                { CatanResourceType.Wood, 0 },
-                { CatanResourceType.Brick, 0 },
-                { CatanResourceType.Sheep, 0 },
-                { CatanResourceType.Wheat, 0 },
-                { CatanResourceType.Ore, 0 }
-            };
-        }
-
-        private Dictionary<CatanDevelopmentCardType, int> InitialiseDevelopmentCards()
-        {
-            return new Dictionary<CatanDevelopmentCardType, int>()
-            {
-                { CatanDevelopmentCardType.Knight, 0 },
-                { CatanDevelopmentCardType.RoadBuilding, 0 },
-                { CatanDevelopmentCardType.YearOfPlenty, 0 },
-                { CatanDevelopmentCardType.Monopoly, 0 },
-                { CatanDevelopmentCardType.VictoryPoint, 0 }
-            };
-        }
+            { CatanDevelopmentCardType.Knight, 0 },
+            { CatanDevelopmentCardType.RoadBuilding, 0 },
+            { CatanDevelopmentCardType.YearOfPlenty, 0 },
+            { CatanDevelopmentCardType.Monopoly, 0 },
+            { CatanDevelopmentCardType.VictoryPoint, 0 }
+        };
     }
 }

--- a/Catan/Catan.Domain/CatanPort.cs
+++ b/Catan/Catan.Domain/CatanPort.cs
@@ -1,16 +1,15 @@
 ﻿using static Catan.Common.Enumerations;
 
-namespace Catan.Domain
-{
-    public sealed class CatanPort
-    {
-        public CatanPortType Type { get; }
-        public Coordinates Coordinates { get; }
+namespace Catan.Domain;
 
-        public CatanPort(CatanPortType type, Coordinates coordinates)
-        {
-            this.Type = type;
-            this.Coordinates = coordinates;
-        }
+public sealed class CatanPort
+{
+    public CatanPort(CatanPortType type, Coordinates coordinates)
+    {
+        Type = type;
+        Coordinates = coordinates;
     }
+    public CatanPortType Type { get; private set; }
+
+    public Coordinates Coordinates { get; private set; }
 }

--- a/Catan/Catan.Domain/CatanRoad.cs
+++ b/Catan/Catan.Domain/CatanRoad.cs
@@ -1,18 +1,20 @@
 ﻿using static Catan.Common.Enumerations;
 
-namespace Catan.Domain
-{
-    public class CatanRoad : CatanBuilding
-    {
-        public Coordinates FirstCornerCoordinates { get; }
-        public Coordinates SecondCornerCoordinates { get; }
+namespace Catan.Domain;
 
-        public CatanRoad(CatanPlayerColour colour, Coordinates firstCornerCoordinates, Coordinates secondCornerCoordinates)
-        {
-            this.Colour = colour;
-            this.Type = CatanBuildingType.Road;
-            this.FirstCornerCoordinates = firstCornerCoordinates;
-            this.SecondCornerCoordinates = secondCornerCoordinates;
-        }
+public class CatanRoad : CatanBuilding
+{
+    public CatanRoad(
+        CatanPlayerColour colour,
+        Coordinates firstCornerCoordinates,
+        Coordinates secondCornerCoordinates)
+        : base(colour, CatanBuildingType.Road)
+    {
+        FirstCornerCoordinates = firstCornerCoordinates;
+        SecondCornerCoordinates = secondCornerCoordinates;
     }
+
+    public Coordinates FirstCornerCoordinates { get; private set; }
+
+    public Coordinates SecondCornerCoordinates { get; private set; }
 }

--- a/Catan/Catan.Domain/CatanTile.cs
+++ b/Catan/Catan.Domain/CatanTile.cs
@@ -1,16 +1,16 @@
 ﻿using static Catan.Common.Enumerations;
 
-namespace Catan.Domain
-{
-    public sealed class CatanTile
-    {
-        public CatanResourceType Type { get; }
-        public int ActivationNumber { get; }
+namespace Catan.Domain;
 
-        public CatanTile(CatanResourceType type, int activationNumber)
-        {
-            this.Type = type;
-            this.ActivationNumber = activationNumber;
-        }
+public sealed class CatanTile
+{
+    public CatanTile(CatanResourceType type, int activationNumber)
+    {
+        Type = type;
+        ActivationNumber = activationNumber;
     }
+
+    public CatanResourceType Type { get; private set; }
+    
+    public int ActivationNumber { get; private set; }
 }

--- a/Catan/Catan.Domain/Coordinates.cs
+++ b/Catan/Catan.Domain/Coordinates.cs
@@ -1,30 +1,23 @@
-﻿namespace Catan.Domain
+﻿namespace Catan.Domain;
+
+public sealed class Coordinates
 {
-    public sealed class Coordinates
+    public Coordinates(int x, int y)
     {
-        public int X { get; set; }
-
-        public int Y { get; set; }
-
-        public Coordinates(int x, int y)
-        {
-            this.X = x;
-            this.Y = y;
-        }
-
-        public bool Equals(Coordinates coordinatesToCompare)
-        {
-            return (this.X == coordinatesToCompare.X && this.Y == coordinatesToCompare.Y);
-        }
-
-        public static Coordinates Add(Coordinates c1, Coordinates c2)
-        {
-            return new Coordinates(c1.X + c2.X, c1.Y + c2.Y);
-        }
-
-        public static Coordinates Subtract(Coordinates c1, Coordinates c2)
-        {
-            return new Coordinates(c2.X - c1.X, c2.Y - c1.Y);
-        }
+        X = x;
+        Y = y;
     }
+
+    public int X { get; private set; }
+
+    public int Y { get; private set; }
+
+    public bool Equals(Coordinates coordinatesToCompare)
+        => X == coordinatesToCompare.X && Y == coordinatesToCompare.Y;
+
+    public static Coordinates Add(Coordinates c1, Coordinates c2)
+    => new(c1.X + c2.X, c1.Y + c2.Y);
+
+    public static Coordinates Subtract(Coordinates c1, Coordinates c2)
+    => new(c2.X - c1.X, c2.Y - c1.Y);
 }

--- a/Catan/Catan.Domain/DiceRoller.cs
+++ b/Catan/Catan.Domain/DiceRoller.cs
@@ -1,20 +1,19 @@
-﻿namespace Catan.Domain
+﻿namespace Catan.Domain;
+
+public static class DiceRoller
 {
-    public static class DiceRoller
+    private static readonly Random random = new();
+
+    public static List<int> RollDice(int numberOfDice, int diceSides)
     {
-        private static readonly Random random = new Random();
+        List<int> rolledDice = new();
 
-        public static List<int> RollDice(int numberOfDice, int diceSides)
+        for (var i = 0; i < numberOfDice; i++)
         {
-            List<int> rolledDice = new();
-
-            for (var i = 0; i < numberOfDice; i++)
-            {
-                var numberRolled = random.Next(diceSides) + 1;
-                rolledDice.Add(numberRolled);
-            }
-
-            return rolledDice;
+            var numberRolled = random.Next(diceSides) + 1;
+            rolledDice.Add(numberRolled);
         }
+
+        return rolledDice;
     }
 }

--- a/Catan/Catan.Domain/DomainConstants.cs
+++ b/Catan/Catan.Domain/DomainConstants.cs
@@ -1,77 +1,68 @@
 ﻿using static Catan.Common.Enumerations;
 
-namespace Catan.Domain
+namespace Catan.Domain;
+
+public static class DomainConstants
 {
-    public static class DomainConstants
-    {
-        public static Dictionary<CatanResourceType, int> GetTileResourceTypeTotals()
+    public static Dictionary<CatanResourceType, int> GetTileResourceTypeTotals()
+        => new()
         {
-            return new Dictionary<CatanResourceType, int>()
-            {
-                { CatanResourceType.Wood, 4 },
-                { CatanResourceType.Brick, 3 },
-                { CatanResourceType.Sheep, 4 },
-                { CatanResourceType.Wheat, 4 },
-                { CatanResourceType.Ore, 3 },
-                { CatanResourceType.Desert, 1 }
-            };
-        }
+            { CatanResourceType.Wood, 4 },
+            { CatanResourceType.Brick, 3 },
+            { CatanResourceType.Sheep, 4 },
+            { CatanResourceType.Wheat, 4 },
+            { CatanResourceType.Ore, 3 },
+            { CatanResourceType.Desert, 1 }
+        };
 
-        public static Dictionary<int, int> GetTileActivationNumberTotals()
+    public static Dictionary<int, int> GetTileActivationNumberTotals()
+        => new()
         {
-            return new Dictionary<int, int>()
-            {
-                { 2, 1 },
-                { 3, 2 },
-                { 4, 2 },
-                { 5, 2 },
-                { 6, 2 },
-                { 7, 0 },
-                { 8, 2 },
-                { 9, 2 },
-                { 10, 2 },
-                { 11, 2 },
-                { 12, 1 }
-            };
-        }
+            { 2, 1 },
+            { 3, 2 },
+            { 4, 2 },
+            { 5, 2 },
+            { 6, 2 },
+            { 7, 0 },
+            { 8, 2 },
+            { 9, 2 },
+            { 10, 2 },
+            { 11, 2 },
+            { 12, 1 }
+        };
 
-        public static List<Coordinates> GetStartingPortCoordinates()
+    public static List<Coordinates> GetStartingPortCoordinates()
+        => new()
         {
-            return new List<Coordinates>()
-            {
-                new Coordinates(2, 0),
-                new Coordinates(3, 0),
-                new Coordinates(5, 0),
-                new Coordinates(6, 0),
-                new Coordinates(1, 1),
-                new Coordinates(1, 2),
-                new Coordinates(8, 1),
-                new Coordinates(9, 1),
-                new Coordinates(10, 2),
-                new Coordinates(10, 3),
-                new Coordinates(1, 3),
-                new Coordinates(1, 4),
-                new Coordinates(8, 4),
-                new Coordinates(9, 4),
-                new Coordinates(2, 5),
-                new Coordinates(3, 5),
-                new Coordinates(5, 5),
-                new Coordinates(6, 5)
-            };
-        }
+            new(2, 0),
+            new(3, 0),
+            new(5, 0),
+            new(6, 0),
+            new(1, 1),
+            new(1, 2),
+            new(8, 1),
+            new(9, 1),
+            new(10, 2),
+            new(10, 3),
+            new(1, 3),
+            new(1, 4),
+            new(8, 4),
+            new(9, 4),
+            new(2, 5),
+            new(3, 5),
+            new(5, 5),
+            new(6, 5)
+        };
 
-        public static Dictionary<CatanPortType, int> GetPortTypeTotals()
+    public static Dictionary<CatanPortType, int> GetPortTypeTotals()
+        => new()
         {
-            return new Dictionary<CatanPortType, int>()
-            {
-                { CatanPortType.None, 0},
-                { CatanPortType.Wood, 1 },
-                { CatanPortType.Brick, 1 },
-                { CatanPortType.Sheep, 1 },
-                { CatanPortType.Wheat, 1 },
-                { CatanPortType.Ore, 1 },
-                { CatanPortType.ThreeToOne, 4 }
-            };
-        }
-    }
+            { CatanPortType.None, 0},
+            { CatanPortType.Wood, 1 },
+            { CatanPortType.Brick, 1 },
+            { CatanPortType.Sheep, 1 },
+            { CatanPortType.Wheat, 1 },
+            { CatanPortType.Ore, 1 },
+            { CatanPortType.ThreeToOne, 4 }
+        };
 }

--- a/Catan/Catan.UnitTests/Domain/CatanBoardTests.cs
+++ b/Catan/Catan.UnitTests/Domain/CatanBoardTests.cs
@@ -1,219 +1,218 @@
 ﻿using Catan.Domain;
 using static Catan.Common.Enumerations;
 
-namespace Catan.UnitTests.Domain
+namespace Catan.UnitTests.Domain;
+
+public sealed class CatanBoardTests
 {
-    public sealed class CatanBoardTests
+    [Fact]
+    public void CreateCatanBoard_EmptyTilesAreNull()
     {
-        [Fact]
-        public void CreateCatanBoard_EmptyTilesAreNull()
-        {
-            // Act
-            var board = new CatanBoard();
-            var tiles = board.GetTiles();
+        // Act
+        var board = new CatanBoard();
+        var tiles = board.GetTiles();
 
-            // Assert
-            Assert.Null(tiles[0, 0]);
-            Assert.Null(tiles[0, 1]);
-            Assert.Null(tiles[1, 0]);
-            Assert.Null(tiles[4, 3]);
-            Assert.Null(tiles[4, 4]);
-            Assert.Null(tiles[3, 4]);
+        // Assert
+        Assert.Null(tiles[0, 0]);
+        Assert.Null(tiles[0, 1]);
+        Assert.Null(tiles[1, 0]);
+        Assert.Null(tiles[4, 3]);
+        Assert.Null(tiles[4, 4]);
+        Assert.Null(tiles[3, 4]);
+    }
+
+    [Fact]
+    public void CreateCatanBoard_CorrectResourceCounts()
+    {
+        // Arrange
+        var resourceCounts = DomainConstants.GetTileResourceTypeTotals();
+
+        // Act
+        var board = new CatanBoard();
+        var tiles = board.GetTiles();
+
+        foreach (var tile in tiles)
+        {
+            if (tile is null) continue;
+
+            var tileType = tile.Type;
+
+            resourceCounts[tileType]--;
         }
 
-        [Fact]
-        public void CreateCatanBoard_CorrectResourceCounts()
+        Assert.Equal(0, resourceCounts[CatanResourceType.Wood]);
+        Assert.Equal(0, resourceCounts[CatanResourceType.Brick]);
+        Assert.Equal(0, resourceCounts[CatanResourceType.Sheep]);
+        Assert.Equal(0, resourceCounts[CatanResourceType.Wheat]);
+        Assert.Equal(0, resourceCounts[CatanResourceType.Ore]);
+        Assert.Equal(0, resourceCounts[CatanResourceType.Desert]);
+    }
+
+    [Fact]
+    public void CreateCatanBoard_CorrectActivationNumberCounts()
+    {
+        // Arrange
+        var activationNumberCounts = DomainConstants.GetTileActivationNumberTotals();
+
+        // Act
+        var board = new CatanBoard();
+        var tiles = board.GetTiles();
+
+        foreach (var tile in tiles)
         {
-            // Arrange
-            var resourceCounts = DomainConstants.GetTileResourceTypeTotals();
+            if (tile is null) continue;
 
-            // Act
-            var board = new CatanBoard();
-            var tiles = board.GetTiles();
+            var tileNumber = tile.ActivationNumber;
 
-            foreach (var tile in tiles)
-            {
-                if (tile is null) continue;
+            if (tileNumber == 0) continue;
 
-                var tileType = tile.Type;
-
-                resourceCounts[tileType]--;
-            }
-
-            Assert.Equal(0, resourceCounts[CatanResourceType.Wood]);
-            Assert.Equal(0, resourceCounts[CatanResourceType.Brick]);
-            Assert.Equal(0, resourceCounts[CatanResourceType.Sheep]);
-            Assert.Equal(0, resourceCounts[CatanResourceType.Wheat]);
-            Assert.Equal(0, resourceCounts[CatanResourceType.Ore]);
-            Assert.Equal(0, resourceCounts[CatanResourceType.Desert]);
+            activationNumberCounts[tileNumber]--;
         }
 
-        [Fact]
-        public void CreateCatanBoard_CorrectActivationNumberCounts()
+        Assert.Equal(0, activationNumberCounts[2]);
+        Assert.Equal(0, activationNumberCounts[3]);
+        Assert.Equal(0, activationNumberCounts[4]);
+        Assert.Equal(0, activationNumberCounts[5]);
+        Assert.Equal(0, activationNumberCounts[6]);
+        Assert.Equal(0, activationNumberCounts[7]);
+        Assert.Equal(0, activationNumberCounts[8]);
+        Assert.Equal(0, activationNumberCounts[9]);
+        Assert.Equal(0, activationNumberCounts[10]);
+        Assert.Equal(0, activationNumberCounts[11]);
+        Assert.Equal(0, activationNumberCounts[12]);
+    }
+
+    [Fact]
+    public void CreateCatanBoard_EmptySettlementsAndCitiesAreNull()
+    {
+        // Act
+        var board = new CatanBoard();
+        var houses = board.GetHouses();
+        int notNullCount = 0;
+
+        foreach(var house in houses)
         {
-            // Arrange
-            var activationNumberCounts = DomainConstants.GetTileActivationNumberTotals();
-
-            // Act
-            var board = new CatanBoard();
-            var tiles = board.GetTiles();
-
-            foreach (var tile in tiles)
-            {
-                if (tile is null) continue;
-
-                var tileNumber = tile.ActivationNumber;
-
-                if (tileNumber == 0) continue;
-
-                activationNumberCounts[tileNumber]--;
-            }
-
-            Assert.Equal(0, activationNumberCounts[2]);
-            Assert.Equal(0, activationNumberCounts[3]);
-            Assert.Equal(0, activationNumberCounts[4]);
-            Assert.Equal(0, activationNumberCounts[5]);
-            Assert.Equal(0, activationNumberCounts[6]);
-            Assert.Equal(0, activationNumberCounts[7]);
-            Assert.Equal(0, activationNumberCounts[8]);
-            Assert.Equal(0, activationNumberCounts[9]);
-            Assert.Equal(0, activationNumberCounts[10]);
-            Assert.Equal(0, activationNumberCounts[11]);
-            Assert.Equal(0, activationNumberCounts[12]);
+            if (house != null) notNullCount++;
         }
 
-        [Fact]
-        public void CreateCatanBoard_EmptySettlementsAndCitiesAreNull()
+        // Assert
+        Assert.Null(houses[0, 0]);
+        Assert.Null(houses[0, 1]);
+        Assert.Null(houses[1, 0]);
+        Assert.Null(houses[0, 4]);
+        Assert.Null(houses[0, 5]);
+        Assert.Null(houses[1, 5]);
+        Assert.Null(houses[9, 0]);
+        Assert.Null(houses[10, 0]);
+        Assert.Null(houses[10, 1]);
+        Assert.Null(houses[10, 4]);
+        Assert.Null(houses[10, 5]);
+        Assert.Null(houses[9, 5]);
+
+        Assert.Equal(54, notNullCount);
+    }
+
+    [Fact]
+    public void CreateCatanBoard_IndividualRoadCoordinatesAreAllValid()
+    {
+        // Act
+        var board = new CatanBoard();
+        var roads = board.GetRoads();
+
+        // Assert
+        foreach (var road in roads)
         {
-            // Act
-            var board = new CatanBoard();
-            var houses = board.GetHouses();
-            int notNullCount = 0;
-
-            foreach(var house in houses)
-            {
-                if (house != null) notNullCount++;
-            }
-
-            // Assert
-            Assert.Null(houses[0, 0]);
-            Assert.Null(houses[0, 1]);
-            Assert.Null(houses[1, 0]);
-            Assert.Null(houses[0, 4]);
-            Assert.Null(houses[0, 5]);
-            Assert.Null(houses[1, 5]);
-            Assert.Null(houses[9, 0]);
-            Assert.Null(houses[10, 0]);
-            Assert.Null(houses[10, 1]);
-            Assert.Null(houses[10, 4]);
-            Assert.Null(houses[10, 5]);
-            Assert.Null(houses[9, 5]);
-
-            Assert.Equal(54, notNullCount);
+            Assert.NotEqual(new Coordinates(0, 0), road.FirstCornerCoordinates);
+            Assert.NotEqual(new Coordinates(0, 0), road.SecondCornerCoordinates);
+            Assert.NotEqual(new Coordinates(0, 1), road.FirstCornerCoordinates);
+            Assert.NotEqual(new Coordinates(0, 1), road.SecondCornerCoordinates);
+            Assert.NotEqual(new Coordinates(1, 0), road.FirstCornerCoordinates);
+            Assert.NotEqual(new Coordinates(1, 0), road.SecondCornerCoordinates);
+            Assert.NotEqual(new Coordinates(0, 4), road.FirstCornerCoordinates);
+            Assert.NotEqual(new Coordinates(0, 4), road.SecondCornerCoordinates);
+            Assert.NotEqual(new Coordinates(0, 5), road.FirstCornerCoordinates);
+            Assert.NotEqual(new Coordinates(0, 5), road.SecondCornerCoordinates);
+            Assert.NotEqual(new Coordinates(1, 5), road.FirstCornerCoordinates);
+            Assert.NotEqual(new Coordinates(1, 5), road.SecondCornerCoordinates);
+            Assert.NotEqual(new Coordinates(9, 0), road.FirstCornerCoordinates);
+            Assert.NotEqual(new Coordinates(9, 0), road.SecondCornerCoordinates);
+            Assert.NotEqual(new Coordinates(10, 0), road.FirstCornerCoordinates);
+            Assert.NotEqual(new Coordinates(10, 0), road.SecondCornerCoordinates);
+            Assert.NotEqual(new Coordinates(10, 1), road.FirstCornerCoordinates);
+            Assert.NotEqual(new Coordinates(10, 1), road.SecondCornerCoordinates);
+            Assert.NotEqual(new Coordinates(10, 4), road.FirstCornerCoordinates);
+            Assert.NotEqual(new Coordinates(10, 4), road.SecondCornerCoordinates);
+            Assert.NotEqual(new Coordinates(10, 5), road.FirstCornerCoordinates);
+            Assert.NotEqual(new Coordinates(10, 5), road.SecondCornerCoordinates);
+            Assert.NotEqual(new Coordinates(9, 5), road.FirstCornerCoordinates);
+            Assert.NotEqual(new Coordinates(9, 5), road.SecondCornerCoordinates);
         }
 
-        [Fact]
-        public void CreateCatanBoard_IndividualRoadCoordinatesAreAllValid()
+        Assert.Equal(72, roads.Count);
+    }
+
+    [Fact]
+    public void CreateCatanBoard_CorrectNumberOfPorts()
+    {
+        // Arrange
+        var correctPortLocations = DomainConstants.GetStartingPortCoordinates();
+
+        // Act
+        var board = new CatanBoard();
+        var ports = board.GetPorts();
+
+        // Assert
+        Assert.Equal(correctPortLocations.Count, ports.Count);
+    }
+
+    [Fact]
+    public void CreateCatanBoard_PortsAreAtCorrectLocations()
+    {
+        // Arrange
+        var correctPortLocations = DomainConstants.GetStartingPortCoordinates();
+
+        // Act
+        var board = new CatanBoard();
+        var ports = board.GetPorts();
+
+        // Assert
+        foreach (var portLocation in correctPortLocations)
         {
-            // Act
-            var board = new CatanBoard();
-            var roads = board.GetRoads();
+            var possiblePorts = ports.Where(x => x.Coordinates.Equals(portLocation));
+            Assert.NotEmpty(possiblePorts);
+        }
+    }
 
-            // Assert
-            foreach (var road in roads)
-            {
-                Assert.NotEqual(new Coordinates(0, 0), road.FirstCornerCoordinates);
-                Assert.NotEqual(new Coordinates(0, 0), road.SecondCornerCoordinates);
-                Assert.NotEqual(new Coordinates(0, 1), road.FirstCornerCoordinates);
-                Assert.NotEqual(new Coordinates(0, 1), road.SecondCornerCoordinates);
-                Assert.NotEqual(new Coordinates(1, 0), road.FirstCornerCoordinates);
-                Assert.NotEqual(new Coordinates(1, 0), road.SecondCornerCoordinates);
-                Assert.NotEqual(new Coordinates(0, 4), road.FirstCornerCoordinates);
-                Assert.NotEqual(new Coordinates(0, 4), road.SecondCornerCoordinates);
-                Assert.NotEqual(new Coordinates(0, 5), road.FirstCornerCoordinates);
-                Assert.NotEqual(new Coordinates(0, 5), road.SecondCornerCoordinates);
-                Assert.NotEqual(new Coordinates(1, 5), road.FirstCornerCoordinates);
-                Assert.NotEqual(new Coordinates(1, 5), road.SecondCornerCoordinates);
-                Assert.NotEqual(new Coordinates(9, 0), road.FirstCornerCoordinates);
-                Assert.NotEqual(new Coordinates(9, 0), road.SecondCornerCoordinates);
-                Assert.NotEqual(new Coordinates(10, 0), road.FirstCornerCoordinates);
-                Assert.NotEqual(new Coordinates(10, 0), road.SecondCornerCoordinates);
-                Assert.NotEqual(new Coordinates(10, 1), road.FirstCornerCoordinates);
-                Assert.NotEqual(new Coordinates(10, 1), road.SecondCornerCoordinates);
-                Assert.NotEqual(new Coordinates(10, 4), road.FirstCornerCoordinates);
-                Assert.NotEqual(new Coordinates(10, 4), road.SecondCornerCoordinates);
-                Assert.NotEqual(new Coordinates(10, 5), road.FirstCornerCoordinates);
-                Assert.NotEqual(new Coordinates(10, 5), road.SecondCornerCoordinates);
-                Assert.NotEqual(new Coordinates(9, 5), road.FirstCornerCoordinates);
-                Assert.NotEqual(new Coordinates(9, 5), road.SecondCornerCoordinates);
-            }
+    [Fact]
+    public void CreateCatanBoard_PortsAreCorrectTypes()
+    {
+        // Arrange
+        var remainingPortTypeTotals = DomainConstants.GetPortTypeTotals();
 
-            Assert.Equal(72, roads.Count);
+        foreach (var type in remainingPortTypeTotals.Keys)
+        {
+            remainingPortTypeTotals[type] *= 2;
         }
 
-        [Fact]
-        public void CreateCatanBoard_CorrectNumberOfPorts()
+        // Act
+        var board = new CatanBoard();
+        var ports = board.GetPorts();
+
+        // Assert
+        foreach (var port in ports)
         {
-            // Arrange
-            var correctPortLocations = DomainConstants.GetStartingPortCoordinates();
+            if (port is null) continue;
 
-            // Act
-            var board = new CatanBoard();
-            var ports = board.GetPorts();
+            var tileType = port.Type;
 
-            // Assert
-            Assert.Equal(correctPortLocations.Count, ports.Count);
+            remainingPortTypeTotals[tileType]--;
         }
 
-        [Fact]
-        public void CreateCatanBoard_PortsAreAtCorrectLocations()
-        {
-            // Arrange
-            var correctPortLocations = DomainConstants.GetStartingPortCoordinates();
-
-            // Act
-            var board = new CatanBoard();
-            var ports = board.GetPorts();
-
-            // Assert
-            foreach (var portLocation in correctPortLocations)
-            {
-                var possiblePorts = ports.Where(x => x.Coordinates.Equals(portLocation));
-                Assert.NotEmpty(possiblePorts);
-            }
-        }
-
-        [Fact]
-        public void CreateCatanBoard_PortsAreCorrectTypes()
-        {
-            // Arrange
-            var remainingPortTypeTotals = DomainConstants.GetPortTypeTotals();
-
-            foreach (var type in remainingPortTypeTotals.Keys)
-            {
-                remainingPortTypeTotals[type] *= 2;
-            }
-
-            // Act
-            var board = new CatanBoard();
-            var ports = board.GetPorts();
-
-            // Assert
-            foreach (var port in ports)
-            {
-                if (port is null) continue;
-
-                var tileType = port.Type;
-
-                remainingPortTypeTotals[tileType]--;
-            }
-
-            Assert.Equal(0, remainingPortTypeTotals[CatanPortType.Wood]);
-            Assert.Equal(0, remainingPortTypeTotals[CatanPortType.Brick]);
-            Assert.Equal(0, remainingPortTypeTotals[CatanPortType.Sheep]);
-            Assert.Equal(0, remainingPortTypeTotals[CatanPortType.Wheat]);
-            Assert.Equal(0, remainingPortTypeTotals[CatanPortType.Ore]);
-            Assert.Equal(0, remainingPortTypeTotals[CatanPortType.ThreeToOne]);
-        }
+        Assert.Equal(0, remainingPortTypeTotals[CatanPortType.Wood]);
+        Assert.Equal(0, remainingPortTypeTotals[CatanPortType.Brick]);
+        Assert.Equal(0, remainingPortTypeTotals[CatanPortType.Sheep]);
+        Assert.Equal(0, remainingPortTypeTotals[CatanPortType.Wheat]);
+        Assert.Equal(0, remainingPortTypeTotals[CatanPortType.Ore]);
+        Assert.Equal(0, remainingPortTypeTotals[CatanPortType.ThreeToOne]);
     }
 }

--- a/Catan/Catan.UnitTests/Domain/DiceRollerTests.cs
+++ b/Catan/Catan.UnitTests/Domain/DiceRollerTests.cs
@@ -1,40 +1,39 @@
 ﻿using Catan.Domain;
 
-namespace Catan.UnitTests.Domain
+namespace Catan.UnitTests.Domain;
+
+public class DiceRollerTests
 {
-    public class DiceRollerTests
+    [Theory]
+    [InlineData(0, 3)]
+    [InlineData(1, 8)]
+    [InlineData(2, 9)]
+    [InlineData(400, 2)]
+    [InlineData(999, 3)]
+    public void RollDice_CorrectNumberOfDiceRolled(int numberOfDice, int diceSides)
     {
-        [Theory]
-        [InlineData(0, 3)]
-        [InlineData(1, 8)]
-        [InlineData(2, 9)]
-        [InlineData(400, 2)]
-        [InlineData(999, 3)]
-        public void RollDice_CorrectNumberOfDiceRolled(int numberOfDice, int diceSides)
+        // Act
+        var rolledDice = DiceRoller.RollDice(numberOfDice, diceSides);
+
+        // Assert
+        int rolledDiceCount = rolledDice.Count;
+        Assert.Equal(rolledDiceCount, numberOfDice);
+    }
+
+    [Fact]
+    public void RollDice_AllDiceValuesWithinMaxSides()
+    {
+        // Arrange
+        int numberOfDice = 100000;
+        int diceSides = 6;
+
+        // Act
+        var rolledDice = DiceRoller.RollDice(numberOfDice, diceSides);
+
+        // Assert
+        foreach (var dice in rolledDice)
         {
-            // Act
-            var rolledDice = DiceRoller.RollDice(numberOfDice, diceSides);
-
-            // Assert
-            int rolledDiceCount = rolledDice.Count;
-            Assert.Equal(rolledDiceCount, numberOfDice);
-        }
-
-        [Fact]
-        public void RollDice_AllDiceValuesWithinMaxSides()
-        {
-            // Arrange
-            int numberOfDice = 100000;
-            int diceSides = 6;
-
-            // Act
-            var rolledDice = DiceRoller.RollDice(numberOfDice, diceSides);
-
-            // Assert
-            foreach (var dice in rolledDice)
-            {
-                Assert.InRange(dice, 1, diceSides);
-            }
+            Assert.InRange(dice, 1, diceSides);
         }
     }
 }

--- a/Catan/Common/Enumerations.cs
+++ b/Catan/Common/Enumerations.cs
@@ -1,54 +1,53 @@
-﻿namespace Catan.Common
+﻿namespace Catan.Common;
+
+public static class Enumerations
 {
-    public static class Enumerations
+    public enum CatanResourceType
     {
-        public enum CatanResourceType
-        {
-            None = 0,
-            Wood = 1,
-            Brick = 2,
-            Sheep = 3,
-            Wheat = 4,
-            Ore = 5,
-            Desert = 6
-        }
+        None = 0,
+        Wood = 1,
+        Brick = 2,
+        Sheep = 3,
+        Wheat = 4,
+        Ore = 5,
+        Desert = 6
+    }
 
-        public enum CatanPlayerColour
-        {
-            None = 0,
-            Red = 1,
-            Blue = 2,
-            Green = 3,
-            Yellow = 4
-        }
+    public enum CatanPlayerColour
+    {
+        None = 0,
+        Red = 1,
+        Blue = 2,
+        Green = 3,
+        Yellow = 4
+    }
 
-        public enum CatanBuildingType
-        {
-            None = 0,
-            Road = 1,
-            Settlement = 2,
-            City = 3
-        }
+    public enum CatanBuildingType
+    {
+        None = 0,
+        Road = 1,
+        Settlement = 2,
+        City = 3
+    }
 
-        public enum CatanPortType
-        {
-            None = 0,
-            Wood = 1,
-            Brick = 2,
-            Sheep = 3,
-            Wheat = 4,
-            Ore = 5,
-            ThreeToOne = 6
-        }
+    public enum CatanPortType
+    {
+        None = 0,
+        Wood = 1,
+        Brick = 2,
+        Sheep = 3,
+        Wheat = 4,
+        Ore = 5,
+        ThreeToOne = 6
+    }
 
-        public enum CatanDevelopmentCardType
-        {
-            None = 0,
-            Knight = 1,
-            RoadBuilding = 2,
-            YearOfPlenty = 3,
-            Monopoly = 4,
-            VictoryPoint = 5
-        }
+    public enum CatanDevelopmentCardType
+    {
+        None = 0,
+        Knight = 1,
+        RoadBuilding = 2,
+        YearOfPlenty = 3,
+        Monopoly = 4,
+        VictoryPoint = 5
     }
 }


### PR DESCRIPTION
Convert to file-scoped namespaces.
Move public properties below constructor.
Use new() where possible.
Fix property scopes.